### PR TITLE
Updated original Slick package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,6 +13,6 @@
   ],
   "dependencies": {
     "jquery": "~1",
-    "slick-carousel": "~1.4.1"
+    "slick.js": "~1.5.5"
   }
 }


### PR DESCRIPTION
Looks like it's "slick.js" rather than "slick-carousel".