### PR TITLE
Add main (entry point) file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "slick-lightbox",
   "version": "0.1.21",
+  "main": "dist/slick-lightbox.js",
   "devDependencies": {
     "coffee-script": "~1.7.1",
     "coffeedoc": "~0.3.1",


### PR DESCRIPTION
Anyone installing slick-lightbox via npm would have to do something
like:

```
require('slick-lightbox/dist/slick-lightbox.js')
```

By defining the compiled js distribution file as the entry point, users
can just do:

```
require('slick-lightbox')
```

Note that I have purposely preferred not to use the minified js file as the
entry file, since this would be an unexpected behaviour IMO, they can
minify it in their asset pipeline.